### PR TITLE
Improve VPN comparison table

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,0 +1,413 @@
+---
+---
+
+@import "{{ site.theme }}";
+
+:root {
+  --vpn-ink: #0f172a;
+  --vpn-muted: #64748b;
+  --vpn-line: #dbe5e3;
+  --vpn-soft: #f1f8f6;
+  --vpn-green: #087f6b;
+  --vpn-green-dark: #076356;
+  --vpn-mint: #2dd4bf;
+  --vpn-gold: #f59e0b;
+}
+
+.main-content {
+  max-width: 74rem;
+}
+
+.vpn-comparison {
+  margin: 2rem 0;
+  color: var(--vpn-ink);
+  font-family: Inter, "PingFang SC", "Microsoft YaHei", Arial, sans-serif;
+}
+
+.vpn-comparison__heading {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 1.5rem 1.6rem;
+  border-radius: 1.25rem 1.25rem 0 0;
+  background:
+    radial-gradient(circle at 85% 10%, rgba(45, 212, 191, .28), transparent 30%),
+    linear-gradient(135deg, #073b35, #087f6b);
+  color: #fff;
+}
+
+.vpn-comparison__heading h2 {
+  margin: .2rem 0 .45rem;
+  color: #fff;
+  border: 0;
+  font-size: clamp(1.4rem, 3vw, 2rem);
+  font-weight: 800;
+}
+
+.vpn-comparison__heading p {
+  margin: 0;
+  color: rgba(255, 255, 255, .82);
+  line-height: 1.65;
+}
+
+.vpn-comparison__eyebrow {
+  font-size: .75rem;
+  font-weight: 800;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+}
+
+.vpn-comparison__updated {
+  flex: 0 0 auto;
+  padding: .65rem .85rem;
+  border: 1px solid rgba(255, 255, 255, .22);
+  border-radius: .8rem;
+  background: rgba(255, 255, 255, .1);
+  text-align: right;
+  backdrop-filter: blur(8px);
+}
+
+.vpn-comparison__updated span,
+.vpn-comparison__updated strong {
+  display: block;
+}
+
+.vpn-comparison__updated span {
+  margin-bottom: .15rem;
+  color: rgba(255, 255, 255, .7);
+  font-size: .68rem;
+}
+
+.vpn-comparison__highlights {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: .55rem;
+  padding: .8rem;
+  border: 1px solid var(--vpn-line);
+  border-top: 0;
+  background: #fff;
+}
+
+.vpn-comparison__highlights span {
+  padding: .6rem .7rem;
+  border-radius: .6rem;
+  background: var(--vpn-soft);
+  color: #28534c;
+  font-size: .74rem;
+  font-weight: 700;
+  text-align: center;
+}
+
+.vpn-table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--vpn-line);
+  border-top: 0;
+  background: #fff;
+  box-shadow: 0 18px 45px rgba(15, 23, 42, .09);
+  -webkit-overflow-scrolling: touch;
+}
+
+.vpn-table {
+  width: 100%;
+  min-width: 1050px;
+  margin: 0;
+  border: 0;
+  border-collapse: separate;
+  border-spacing: 0;
+  font-size: .79rem;
+}
+
+.vpn-table th,
+.vpn-table td {
+  border: 0;
+  border-right: 1px solid #e8efed;
+  border-bottom: 1px solid #e8efed;
+  vertical-align: middle;
+}
+
+.vpn-table th:last-child,
+.vpn-table td:last-child {
+  border-right: 0;
+}
+
+.vpn-table thead th {
+  padding: .8rem .7rem;
+  background: #eaf5f2;
+  color: #345c55;
+  font-size: .7rem;
+  font-weight: 800;
+  letter-spacing: .03em;
+  white-space: nowrap;
+}
+
+.vpn-table tbody td {
+  padding: 1rem .7rem;
+  color: #334155;
+  line-height: 1.5;
+}
+
+.vpn-table tbody tr:nth-child(even) {
+  background: #fbfdfc;
+}
+
+.vpn-table tbody tr:hover {
+  background: #f3faf8;
+}
+
+.vpn-table__winner {
+  background: linear-gradient(90deg, #edfbf7, #fff) !important;
+}
+
+.vpn-table small {
+  display: block;
+  margin-top: .2rem;
+  color: var(--vpn-muted);
+  font-size: .68rem;
+  line-height: 1.45;
+}
+
+.vpn-brand {
+  display: flex;
+  align-items: flex-start;
+  gap: .65rem;
+  min-width: 8.5rem;
+}
+
+.vpn-brand strong {
+  display: block;
+  margin-bottom: .4rem;
+  color: var(--vpn-ink);
+  font-size: .95rem;
+}
+
+.vpn-brand__rank {
+  display: inline-grid;
+  flex: 0 0 1.8rem;
+  width: 1.8rem;
+  height: 1.8rem;
+  place-items: center;
+  border-radius: .55rem;
+  background: #d8ede8;
+  color: var(--vpn-green-dark);
+  font-weight: 900;
+}
+
+.vpn-table__winner .vpn-brand__rank {
+  background: linear-gradient(135deg, #fcd34d, #f59e0b);
+  color: #713f12;
+  box-shadow: 0 5px 12px rgba(245, 158, 11, .25);
+}
+
+.vpn-tag {
+  display: inline-block;
+  padding: .22rem .45rem;
+  border-radius: 999px;
+  font-size: .63rem;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.vpn-tag--green { background: #d9f7ef; color: #087461; }
+.vpn-tag--orange { background: #fff0df; color: #b45309; }
+.vpn-tag--yellow { background: #fff8cf; color: #92610a; }
+.vpn-tag--blue { background: #e7f0ff; color: #1d4ed8; }
+
+.vpn-cta {
+  display: block;
+  margin-top: .75rem;
+  padding: .5rem .65rem;
+  border-radius: .55rem;
+  background: var(--vpn-green);
+  color: #fff !important;
+  font-size: .72rem;
+  font-weight: 800;
+  text-align: center;
+  text-decoration: none;
+  transition: transform .18s ease, background .18s ease, box-shadow .18s ease;
+}
+
+.vpn-cta:hover {
+  background: var(--vpn-green-dark);
+  box-shadow: 0 7px 15px rgba(8, 127, 107, .2);
+  text-decoration: none;
+  transform: translateY(-1px);
+}
+
+.vpn-success {
+  display: block;
+  margin-bottom: .35rem;
+  color: var(--vpn-green);
+  font-size: 1rem;
+}
+
+.vpn-meter {
+  display: block;
+  width: 4.2rem;
+  height: .32rem;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #dfeae7;
+}
+
+.vpn-meter span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--vpn-green), var(--vpn-mint));
+}
+
+.vpn-status {
+  display: inline-grid;
+  width: 1.1rem;
+  height: 1.1rem;
+  margin-right: .18rem;
+  place-items: center;
+  border-radius: 50%;
+  background: #d9f7ef;
+  color: var(--vpn-green);
+  font-size: .7rem;
+  font-weight: 900;
+}
+
+.vpn-price {
+  display: block;
+  color: var(--vpn-ink);
+  font-size: .95rem;
+}
+
+.vpn-price small {
+  display: inline;
+  font-weight: 500;
+}
+
+.vpn-stars {
+  color: var(--vpn-gold);
+  font-size: .8rem;
+  letter-spacing: .02em;
+  white-space: nowrap;
+}
+
+.vpn-score {
+  color: var(--vpn-green);
+  font-size: 1.15rem;
+}
+
+.vpn-comparison__note {
+  margin: 0;
+  padding: .85rem 1rem;
+  border: 1px solid var(--vpn-line);
+  border-top: 0;
+  border-radius: 0 0 1.25rem 1.25rem;
+  background: #f8fbfa;
+  color: var(--vpn-muted);
+  font-size: .72rem;
+  line-height: 1.65;
+}
+
+@media (max-width: 760px) {
+  .vpn-comparison__heading {
+    align-items: flex-start;
+    padding: 1.25rem;
+  }
+
+  .vpn-comparison__updated {
+    display: none;
+  }
+
+  .vpn-comparison__highlights {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .vpn-table-wrap {
+    overflow: visible;
+    border: 0;
+    background: transparent;
+    box-shadow: none;
+  }
+
+  .vpn-table,
+  .vpn-table tbody,
+  .vpn-table tr,
+  .vpn-table td {
+    display: block;
+    width: 100%;
+    min-width: 0;
+    box-sizing: border-box;
+  }
+
+  .vpn-table thead {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+  }
+
+  .vpn-table tbody tr {
+    margin-top: .8rem;
+    overflow: hidden;
+    border: 1px solid var(--vpn-line);
+    border-radius: 1rem;
+    background: #fff !important;
+    box-shadow: 0 10px 26px rgba(15, 23, 42, .07);
+  }
+
+  .vpn-table tbody td {
+    display: grid;
+    grid-template-columns: minmax(7rem, 38%) 1fr;
+    gap: .8rem;
+    padding: .7rem 1rem;
+    border: 0;
+    border-bottom: 1px solid #e8efed;
+    text-align: right;
+  }
+
+  .vpn-table tbody td::before {
+    content: attr(data-label);
+    color: var(--vpn-muted);
+    font-size: .72rem;
+    font-weight: 700;
+    text-align: left;
+  }
+
+  .vpn-table tbody td:first-child {
+    display: block;
+    padding: 1rem;
+    background: #f3faf8;
+    text-align: left;
+  }
+
+  .vpn-table tbody td:first-child::before {
+    display: none;
+  }
+
+  .vpn-table tbody td:last-child {
+    border-bottom: 0;
+  }
+
+  .vpn-brand {
+    align-items: center;
+  }
+
+  .vpn-cta {
+    margin-top: .9rem;
+    padding: .68rem;
+  }
+
+  .vpn-meter {
+    margin-left: auto;
+  }
+
+  .vpn-comparison__note {
+    margin-top: .8rem;
+    border-top: 1px solid var(--vpn-line);
+    border-radius: 1rem;
+  }
+}
+
+@media (max-width: 430px) {
+  .vpn-comparison__highlights {
+    grid-template-columns: 1fr;
+  }
+}

--- a/index.md
+++ b/index.md
@@ -46,98 +46,138 @@
 
 以下实测结果基于中国网络环境下的综合表现排序：
 
-<div style="max-width:1200px;margin:30px auto;font-family:Arial,'Microsoft YaHei',sans-serif;overflow-x:auto;-webkit-overflow-scrolling:touch;">
-  <table style="min-width:1100px;width:100%;border-collapse:collapse;background:#fff;border-radius:14px;overflow:hidden;box-shadow:0 8px 24px rgba(0,0,0,0.08);font-size:15px;color:#222;">
-    <thead>
-      <tr style="background:linear-gradient(135deg,#0f766e,#14b8a6);color:#fff;text-align:left;">
-        <th style="padding:16px;border:1px solid #e5e7eb;">VPN 品牌</th>
-        <th style="padding:16px;border:1px solid #e5e7eb;">中国翻墙成功率</th>
-        <th style="padding:16px;border:1px solid #e5e7eb;">连接速度</th>
-        <th style="padding:16px;border:1px solid #e5e7eb;">AI 工具</th>
-        <th style="padding:16px;border:1px solid #e5e7eb;">主流流媒体</th>
-        <th style="padding:16px;border:1px solid #e5e7eb;">价格与支付方式</th>
-        <th style="padding:16px;border:1px solid #e5e7eb;">售后表现</th>
-        <th style="padding:16px;border:1px solid #e5e7eb;">综合评分</th>
-      </tr>
-    </thead>
+<section class="vpn-comparison" aria-labelledby="vpn-ranking-title">
+  <div class="vpn-comparison__heading">
+    <div>
+      <p class="vpn-comparison__eyebrow">2026 中国网络实测</p>
+      <h2 id="vpn-ranking-title">VPN 综合对比速览</h2>
+      <p>按连接成功率、速度、AI 与流媒体可用性、价格和售后综合排序。</p>
+    </div>
+    <div class="vpn-comparison__updated">
+      <span>数据更新</span>
+      <strong>2026.07.22</strong>
+    </div>
+  </div>
 
-    <tbody>
-      <tr style="background:#f0fdfa;">
-        <td style="padding:18px;border:1px solid #e5e7eb;min-width:190px;">
-          <div style="font-size:18px;font-weight:700;color:#111827;margin-bottom:8px;">StrongVPN</div>
-          <div style="display:inline-block;background:#ecfeff;color:#0f766e;font-size:12px;font-weight:700;padding:5px 10px;border-radius:999px;margin-bottom:14px;">🏆 翻墙最稳</div>
-          <br>
-          <a href="https://overwallvpn.com/go/strongvpn" target="_blank" rel="noopener noreferrer" style="display:inline-block;width:100%;box-sizing:border-box;padding:12px 16px;background:linear-gradient(135deg,#0f766e,#14b8a6);color:#fff;font-weight:700;font-size:15px;text-align:center;text-decoration:none;border-radius:10px;box-shadow:0 4px 12px rgba(20,184,166,.25);">
-            🔥 查看官网优惠
-          </a>
-        </td>
-        <td style="padding:15px;border:1px solid #e5e7eb;color:#059669;font-weight:bold;">98%</td>
-        <td style="padding:15px;border:1px solid #e5e7eb;">300–800 Mbps</td>
-        <td style="padding:15px;border:1px solid #e5e7eb;">可稳定访问 ChatGPT、Claude、Gemini 等</td>
-        <td style="padding:15px;border:1px solid #e5e7eb;">可解锁 Netflix、Disney+、YouTube 等</td>
-        <td style="padding:15px;border:1px solid #e5e7eb;"><strong>$3.97/月</strong><br>信用卡、PayPal、支付宝</td>
-        <td style="padding:15px;border:1px solid #e5e7eb;color:#f59e0b;">★★★★★</td>
-        <td style="padding:15px;border:1px solid #e5e7eb;font-weight:bold;color:#059669;">4.9/5</td>
-      </tr>
+  <div class="vpn-comparison__highlights" aria-label="榜单重点">
+    <span>🏆 稳定性首选：StrongVPN</span>
+    <span>⚡ 速度首选：ExpressVPN</span>
+    <span>💰 低价首选：PureVPN</span>
+    <span>👨‍👩‍👧 多设备首选：Surfshark</span>
+  </div>
 
-      <tr>
-        <td style="padding:18px;border:1px solid #e5e7eb;min-width:190px;">
-          <div style="font-size:18px;font-weight:700;color:#111827;margin-bottom:8px;">ExpressVPN</div>
-          <div style="display:inline-block;background:#fff7ed;color:#c2410c;font-size:12px;font-weight:700;padding:5px 10px;border-radius:999px;margin-bottom:14px;">⚡ 极速体验</div>
-          <br>
-          <a href="https://overwallvpn.com/go/expressvpn" target="_blank" rel="noopener noreferrer" style="display:inline-block;width:100%;box-sizing:border-box;padding:12px 16px;background:linear-gradient(135deg,#0f766e,#14b8a6);color:#fff;font-weight:700;font-size:15px;text-align:center;text-decoration:none;border-radius:10px;box-shadow:0 4px 12px rgba(20,184,166,.25);">
-            🔥 查看官网优惠
-          </a>
-        </td>
-        <td style="padding:15px;border:1px solid #e5e7eb;">85%</td>
-        <td style="padding:15px;border:1px solid #e5e7eb;">400–900 Mbps</td>
-        <td style="padding:15px;border:1px solid #e5e7eb;">是，可访问 ChatGPT、Claude 等</td>
-        <td style="padding:15px;border:1px solid #e5e7eb;">支持 Netflix、Disney+、YouTube 等</td>
-        <td style="padding:15px;border:1px solid #e5e7eb;"><strong>$3.99/月</strong><br>信用卡、Google Pay、PayPal</td>
-        <td style="padding:15px;border:1px solid #e5e7eb;color:#f59e0b;">★★★★★</td>
-        <td style="padding:15px;border:1px solid #e5e7eb;font-weight:bold;">4.5/5</td>
-      </tr>
+  <div class="vpn-table-wrap">
+    <table class="vpn-table">
+      <thead>
+        <tr>
+          <th scope="col">排名与品牌</th>
+          <th scope="col">成功率</th>
+          <th scope="col">连接速度</th>
+          <th scope="col">AI 工具</th>
+          <th scope="col">主流流媒体</th>
+          <th scope="col">价格与支付</th>
+          <th scope="col">售后</th>
+          <th scope="col">综合评分</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="vpn-table__winner">
+          <td data-label="排名与品牌">
+            <div class="vpn-brand">
+              <span class="vpn-brand__rank">1</span>
+              <div>
+                <strong>StrongVPN</strong>
+                <span class="vpn-tag vpn-tag--green">🏆 翻墙最稳</span>
+              </div>
+            </div>
+            <a class="vpn-cta" href="https://overwallvpn.com/go/strongvpn" target="_blank" rel="noopener noreferrer">查看官网优惠 <span aria-hidden="true">→</span></a>
+          </td>
+          <td data-label="中国连接成功率">
+            <strong class="vpn-success">98%</strong>
+            <span class="vpn-meter" aria-label="成功率 98%"><span style="width:98%"></span></span>
+          </td>
+          <td data-label="连接速度"><strong>300–800</strong><small>Mbps</small></td>
+          <td data-label="AI 工具"><span class="vpn-status">✓</span> ChatGPT、Claude、Gemini 等</td>
+          <td data-label="主流流媒体"><span class="vpn-status">✓</span> Netflix、Disney+、YouTube 等</td>
+          <td data-label="价格与支付"><strong class="vpn-price">$3.97<small>/月</small></strong><small>信用卡 · PayPal · 支付宝</small></td>
+          <td data-label="售后"><span class="vpn-stars" aria-label="5 星">★★★★★</span></td>
+          <td data-label="综合评分"><strong class="vpn-score">4.9</strong><small>/ 5</small></td>
+        </tr>
 
-      <tr style="background:#f9fafb;">
-        <td style="padding:18px;border:1px solid #e5e7eb;min-width:190px;">
-          <div style="font-size:18px;font-weight:700;color:#111827;margin-bottom:8px;">PureVPN</div>
-          <div style="display:inline-block;background:#fefce8;color:#a16207;font-size:12px;font-weight:700;padding:5px 10px;border-radius:999px;margin-bottom:14px;">💰 性价比高</div>
-          <br>
-          <a href="https://overwallvpn.com/go/purevpn" target="_blank" rel="noopener noreferrer" style="display:inline-block;width:100%;box-sizing:border-box;padding:12px 16px;background:linear-gradient(135deg,#0f766e,#14b8a6);color:#fff;font-weight:700;font-size:15px;text-align:center;text-decoration:none;border-radius:10px;box-shadow:0 4px 12px rgba(20,184,166,.25);">
-            🔥 查看官网优惠
-          </a>
-        </td>
-        <td style="padding:15px;border:1px solid #e5e7eb;">82%</td>
-        <td style="padding:15px;border:1px solid #e5e7eb;">200–600 Mbps</td>
-        <td style="padding:15px;border:1px solid #e5e7eb;">是，可访问主流 AI 工具</td>
-        <td style="padding:15px;border:1px solid #e5e7eb;">支持大部分主流流媒体</td>
-        <td style="padding:15px;border:1px solid #e5e7eb;"><strong>$2.55/月</strong><br>信用卡、Google Pay、PayPal</td>
-        <td style="padding:15px;border:1px solid #e5e7eb;color:#f59e0b;">★★★★☆</td>
-        <td style="padding:15px;border:1px solid #e5e7eb;font-weight:bold;">4.2/5</td>
-      </tr>
+        <tr>
+          <td data-label="排名与品牌">
+            <div class="vpn-brand">
+              <span class="vpn-brand__rank">2</span>
+              <div>
+                <strong>ExpressVPN</strong>
+                <span class="vpn-tag vpn-tag--orange">⚡ 极速体验</span>
+              </div>
+            </div>
+            <a class="vpn-cta" href="https://overwallvpn.com/go/expressvpn" target="_blank" rel="noopener noreferrer">查看官网优惠 <span aria-hidden="true">→</span></a>
+          </td>
+          <td data-label="中国连接成功率">
+            <strong class="vpn-success">85%</strong>
+            <span class="vpn-meter" aria-label="成功率 85%"><span style="width:85%"></span></span>
+          </td>
+          <td data-label="连接速度"><strong>400–900</strong><small>Mbps</small></td>
+          <td data-label="AI 工具"><span class="vpn-status">✓</span> ChatGPT、Claude 等</td>
+          <td data-label="主流流媒体"><span class="vpn-status">✓</span> Netflix、Disney+、YouTube 等</td>
+          <td data-label="价格与支付"><strong class="vpn-price">$3.99<small>/月</small></strong><small>信用卡 · Google Pay · PayPal</small></td>
+          <td data-label="售后"><span class="vpn-stars" aria-label="5 星">★★★★★</span></td>
+          <td data-label="综合评分"><strong class="vpn-score">4.5</strong><small>/ 5</small></td>
+        </tr>
 
-      <tr>
-        <td style="padding:18px;border:1px solid #e5e7eb;min-width:190px;">
-          <div style="font-size:18px;font-weight:700;color:#111827;margin-bottom:8px;">Surfshark</div>
-          <div style="display:inline-block;background:#eff6ff;color:#1d4ed8;font-size:12px;font-weight:700;padding:5px 10px;border-radius:999px;margin-bottom:14px;">👨‍👩‍👧 无限设备</div>
-          <br>
-          <a href="https://overwallvpn.com/go/surfshark" target="_blank" rel="noopener noreferrer" style="display:inline-block;width:100%;box-sizing:border-box;padding:12px 16px;background:linear-gradient(135deg,#0f766e,#14b8a6);color:#fff;font-weight:700;font-size:15px;text-align:center;text-decoration:none;border-radius:10px;box-shadow:0 4px 12px rgba(20,184,166,.25);">
-            🔥 查看官网优惠
-          </a>
-        </td>
-        <td style="padding:15px;border:1px solid #e5e7eb;">80%</td>
-        <td style="padding:15px;border:1px solid #e5e7eb;">350–950 Mbps</td>
-        <td style="padding:15px;border:1px solid #e5e7eb;">是，可访问主流 AI 工具</td>
-        <td style="padding:15px;border:1px solid #e5e7eb;">支持 Netflix、Disney+、YouTube 等</td>
-        <td style="padding:15px;border:1px solid #e5e7eb;"><strong>$4.79/月</strong><br>信用卡、Apple Pay、Google Pay、加密货币</td>
-        <td style="padding:15px;border:1px solid #e5e7eb;color:#f59e0b;">★★★★☆</td>
-        <td style="padding:15px;border:1px solid #e5e7eb;font-weight:bold;">4.0/5</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
+        <tr>
+          <td data-label="排名与品牌">
+            <div class="vpn-brand">
+              <span class="vpn-brand__rank">3</span>
+              <div>
+                <strong>PureVPN</strong>
+                <span class="vpn-tag vpn-tag--yellow">💰 性价比高</span>
+              </div>
+            </div>
+            <a class="vpn-cta" href="https://overwallvpn.com/go/purevpn" target="_blank" rel="noopener noreferrer">查看官网优惠 <span aria-hidden="true">→</span></a>
+          </td>
+          <td data-label="中国连接成功率">
+            <strong class="vpn-success">82%</strong>
+            <span class="vpn-meter" aria-label="成功率 82%"><span style="width:82%"></span></span>
+          </td>
+          <td data-label="连接速度"><strong>200–600</strong><small>Mbps</small></td>
+          <td data-label="AI 工具"><span class="vpn-status">✓</span> 主流 AI 工具</td>
+          <td data-label="主流流媒体"><span class="vpn-status">✓</span> 大部分主流平台</td>
+          <td data-label="价格与支付"><strong class="vpn-price">$2.55<small>/月</small></strong><small>信用卡 · Google Pay · PayPal</small></td>
+          <td data-label="售后"><span class="vpn-stars" aria-label="4 星">★★★★☆</span></td>
+          <td data-label="综合评分"><strong class="vpn-score">4.2</strong><small>/ 5</small></td>
+        </tr>
 
-> **最后更新时间：2026年7月22日**
+        <tr>
+          <td data-label="排名与品牌">
+            <div class="vpn-brand">
+              <span class="vpn-brand__rank">4</span>
+              <div>
+                <strong>Surfshark</strong>
+                <span class="vpn-tag vpn-tag--blue">👨‍👩‍👧 无限设备</span>
+              </div>
+            </div>
+            <a class="vpn-cta" href="https://overwallvpn.com/go/surfshark" target="_blank" rel="noopener noreferrer">查看官网优惠 <span aria-hidden="true">→</span></a>
+          </td>
+          <td data-label="中国连接成功率">
+            <strong class="vpn-success">80%</strong>
+            <span class="vpn-meter" aria-label="成功率 80%"><span style="width:80%"></span></span>
+          </td>
+          <td data-label="连接速度"><strong>350–950</strong><small>Mbps</small></td>
+          <td data-label="AI 工具"><span class="vpn-status">✓</span> 主流 AI 工具</td>
+          <td data-label="主流流媒体"><span class="vpn-status">✓</span> Netflix、Disney+、YouTube 等</td>
+          <td data-label="价格与支付"><strong class="vpn-price">$4.79<small>/月</small></strong><small>信用卡 · Apple Pay · Google Pay · 加密货币</small></td>
+          <td data-label="售后"><span class="vpn-stars" aria-label="4 星">★★★★☆</span></td>
+          <td data-label="综合评分"><strong class="vpn-score">4.0</strong><small>/ 5</small></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <p class="vpn-comparison__note"><strong>说明：</strong>成功率与速度来自帖子记录的中国网络环境测试结果；实际体验会受地区、运营商、节点负载和测试时段影响。价格以页面记录的长期套餐折算价为准，购买前请以官网显示为准。</p>
+</section>
 
 ## 为什么推荐这几款VPN？
 


### PR DESCRIPTION
## 修改内容

- 将帖子顶部的 VPN 对比信息重构为更清晰的排名表格
- 增加排名、特色标签、成功率进度条、价格、售后与综合评分展示
- 增加榜单重点摘要和数据口径说明
- 将大量行内样式拆分到站点 SCSS，方便后续维护
- 为手机端增加卡片式响应布局，避免横向表格难以阅读

## 修改原因

原表格信息密度较高，依赖大量行内样式，在手机端需要横向滚动，且后续更新数据时维护成本较高。本次修改保留原有数据与跳转链接，只优化信息层级、可读性和响应式表现。

## 验证

- `git diff --check` 通过
- HTML 标签嵌套检查通过
- 4 个 VPN 数据行与 4 个官网链接检查通过
- SCSS 包含 760px 和 430px 两档响应式布局

> 成功率、速度、价格与评分均沿用帖子原有记录，没有在本次修改中重新测定。
